### PR TITLE
Update for Zig 0.16.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,17 @@ jobs:
         zig-version: [master]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - zig-version: "0.14.0"
+          - zig-version: "0.14.1"
+            os: ubuntu-latest
+          - zig-version: "0.15.2"
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is [zstd](https://github.com/facebook/zstd), packaged for [Zig](https://ziglang.org/).
 
+Compatible with zig `0.14`-`0.16`
+
 ## Installation
 
 First, update your `build.zig.zon`:
@@ -11,7 +13,7 @@ First, update your `build.zig.zon`:
 ```
 # Initialize a `zig build` project if you haven't already
 zig init
-zig fetch --save git+https://github.com/allyourcodebase/zstd.git#1.5.7
+zig fetch --save git+https://github.com/allyourcodebase/zstd.git#master
 ```
 
 You can then import `zstd` in your `build.zig` with:
@@ -22,4 +24,31 @@ const zstd_dependency = b.dependency("zstd", .{
     .optimize = optimize,
 });
 your_exe.linkLibrary(zstd_dependency.artifact("zstd"));
+```
+
+## Options
+
+```
+  -Dlinkage=[enum]             Link mode. Defaults to static
+                                 Supported Values:
+                                   static
+                                   dynamic
+  -Dstrip=[bool]               Omit debug information
+  -Dpie=[bool]                 Produce Position Independent Code
+  -Dcompression=[bool]         build compression module
+  -Ddecompression=[bool]       build decompression module
+  -Ddictbuilder=[bool]         build dictbuilder module
+  -Ddeprecated=[bool]          build deprecated module
+  -Dminify=[bool]              Configures a bunch of other options to space-optimized defaults
+  -Dlegacy-support=[int]       makes it possible to decompress legacy zstd formats
+  -Dmulti-thread=[bool]        Enable multi-threading
+  -Ddisable-assembly=[bool]    Assembly support
+  -Dhuf-force-decompress-x1=[bool]
+  -Dhuf-force-decompress-x2=[bool]
+  -Dforce-decompress-sequences-short=[bool]
+  -Dforce-decompress-sequences-long=[bool]
+  -Dno-inline=[bool]           Disable Inlining
+  -Dstrip-error-strings=[bool] removes the error messages that are otherwise returned by `ZSTD_getErrorName` (implied by `-Dminify`)
+  -Dexclude-compressors-dfast-and-up=[bool]
+  -Dexclude-compressors-greedy-and-up=[bool]
 ```


### PR DESCRIPTION
The following methods now apply to the module instead of the compile step:
- `addCSourceFiles`
- `addIncludePath`
- `linkLibrary`