### PR TITLE
Methods relative to compilation are applied to the module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,18 +14,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zig-version: [master]
+        zig-version: ["0.15.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - zig-version: "0.14.0"
+          - zig-version: "0.14.1"
+            os: ubuntu-latest
+          - zig-version: "master"
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .zig-cache
-zig-cache
 zig-out

--- a/build.zig
+++ b/build.zig
@@ -48,12 +48,12 @@ pub fn build(b: *std.Build) void {
     zstd.installHeader(upstream.path("lib/zstd.h"), "zstd.h");
     zstd.installHeader(upstream.path("lib/zdict.h"), "zdict.h");
     zstd.installHeader(upstream.path("lib/zstd_errors.h"), "zstd_errors.h");
-    if (compression) zstd.addCSourceFiles(.{ .root = upstream.path("lib"), .files = compression_sources });
-    if (decompression) zstd.addCSourceFiles(.{ .root = upstream.path("lib"), .files = decompress_sources });
-    if (dictbuilder) zstd.addCSourceFiles(.{ .root = upstream.path("lib"), .files = dict_builder_sources });
-    if (deprecated) zstd.addCSourceFiles(.{ .root = upstream.path("lib"), .files = deprecated_sources });
+    if (compression) zstd.root_module.addCSourceFiles(.{ .root = upstream.path("lib"), .files = compression_sources });
+    if (decompression) zstd.root_module.addCSourceFiles(.{ .root = upstream.path("lib"), .files = decompress_sources });
+    if (dictbuilder) zstd.root_module.addCSourceFiles(.{ .root = upstream.path("lib"), .files = dict_builder_sources });
+    if (deprecated) zstd.root_module.addCSourceFiles(.{ .root = upstream.path("lib"), .files = deprecated_sources });
     if (legacy_support != 0) {
-        for (legacy_support..8) |i| zstd.addCSourceFile(.{ .file = upstream.path(b.fmt("lib/legacy/zstd_v0{d}.c", .{i})) });
+        for (legacy_support..8) |i| zstd.root_module.addCSourceFile(.{ .file = upstream.path(b.fmt("lib/legacy/zstd_v0{d}.c", .{i})) });
     }
 
     if (target.result.cpu.arch == .x86_64) {
@@ -110,9 +110,9 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                 }),
             });
-            exe.addCSourceFile(.{ .file = upstream.path(b.fmt("examples/{s}.c", .{name})) });
-            exe.addIncludePath(upstream.path("examples/common.c"));
-            exe.linkLibrary(zstd);
+            exe.root_module.addCSourceFile(.{ .file = upstream.path(b.fmt("examples/{s}.c", .{name})) });
+            exe.root_module.addIncludePath(upstream.path("examples/common.c"));
+            exe.root_module.linkLibrary(zstd);
             b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = .{ .override = .{ .custom = "examples" } } }).step);
         }
     }


### PR DESCRIPTION
The following methods now apply to the module instead of the compile step:
- addCSourceFiles
- addIncludePath
- linkLibrary