### PR TITLE
Bump Zig version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zig-version: ["0.15.2"]
+        zig-version: ["0.16.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - zig-version: "0.14.1"
+            os: ubuntu-latest
+          - zig-version: "0.15.2"
             os: ubuntu-latest
           - zig-version: "master"
             os: ubuntu-latest
@@ -35,4 +37,4 @@ jobs:
         run: zig fmt --ast-check --check .
 
       - name: Build
-        run: zig build --summary all
+        run: zig build --summary new

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .zig-cache
 zig-out
+zig-pkg


### PR DESCRIPTION
Small update to the CI now that `0.16.0` is released